### PR TITLE
Safeguards when converting to boolean

### DIFF
--- a/json_flatten.py
+++ b/json_flatten.py
@@ -86,7 +86,7 @@ def unflatten(data):
                 "int": int,
                 "float": float,
                 "empty": lambda v: {},
-                "bool": lambda v: v.lower() == "true",
+                "bool": lambda v: str(v).lower().strip() == "true",
                 "none": lambda v: None,
             }.get(lasttype, lambda v: v)(value)
         current[lastkey] = value


### PR DESCRIPTION
Added some additional safeguards in the use case where the following key/s are provided:

```
{
    "some.key$bool": True,
    "another.key$bool": "     True      "
}
```